### PR TITLE
ardrone_driver.cpp: ensure timestamps are consistent

### DIFF
--- a/src/ardrone_driver.cpp
+++ b/src/ardrone_driver.cpp
@@ -450,8 +450,8 @@ void ARDroneDriver::publish_video()
         sensor_msgs::Image::_data_type::iterator _it;
 
         image_msg.header.stamp = ros::Time::now();
-        cinfo_msg_hori.header.stamp = ros::Time::now();
-        cinfo_msg_vert.header.stamp = ros::Time::now();
+        cinfo_msg_hori.header.stamp = image_msg.header.stamp; 
+        cinfo_msg_vert.header.stamp = image_msg.header.stamp; 
 
         if (cam_state == ZAP_CHANNEL_HORI)
         {


### PR DESCRIPTION
Calling ros::Time::now() doesn't guarantee timestamps are matched as
ros::Time::now() can change between calls. This fix sets the timestamps to be
equal, to ensure consistency.

This addresses issue #13.
