### PR TITLE
Enable Zero-Command without Hovering

### DIFF
--- a/src/teleop_twist.cpp
+++ b/src/teleop_twist.cpp
@@ -152,7 +152,9 @@ C_RESULT update_teleop(void)
                 (fabs(left_right) < _EPS) && 
                 (fabs(front_back) < _EPS) && 
                 (fabs(up_down) < _EPS) && 
-                (fabs(turn) < _EPS)
+                (fabs(turn) < _EPS) &&
+                (fabs((float) cmd_vel.angular.y) < _EPS) &&
+                (fabs((float) cmd_vel.angular.x) < _EPS)
                 );
         control_flag |= (hover << 0);
         control_flag |= (combined_yaw << 1);


### PR DESCRIPTION
Very simple change; the drone only is set to hover mode if all six Twist parameters are zero.

=> by sending ((0,0,0),(0,0,0)) it is still set to hovering, by setting angular.x or angular.y (which currently is completely unused) to e.g. 1, it is sent a zero-command without hovering.
