### PR TITLE
made loop_rate variable

### DIFF
--- a/src/ardrone_driver.cpp
+++ b/src/ardrone_driver.cpp
@@ -118,7 +118,8 @@ ARDroneDriver::~ARDroneDriver()
 void ARDroneDriver::run()
 {
     // TODO: 50Hz made navdata unstable, I think it is a locking issue.
-    ros::Rate loop_rate(50);
+    double loopRate = getRosParam("~loop_rate",50);
+    ros::Rate loop_rate(loopRate);
     ros::Time startTime = ros::Time::now();
     static int freq_dev = 0;
 	while (node_handle.ok())
@@ -157,7 +158,7 @@ void ARDroneDriver::run()
             }
             if (freq_dev == 0) publish_tf();
 
-            freq_dev = (freq_dev + 1) % 5; // ~10Hz TF publish
+            freq_dev = (freq_dev + 1) % (int)(loopRate/10); // ~10Hz TF publish
         }
         ros::spinOnce();
 		loop_rate.sleep();


### PR DESCRIPTION
I need high-frequency and low-latency navdata (full 200HZ sent by the drone), which I get by setting this to e.g. 500. I dont notice any problems / unstabilities; even cpu usage doesnt change significantly. 

maybe not the cleanest solution, but doesnt change anything as long as you dont change the loop_rate parameter. 

Alternatively, it would be nice to do the ros::publish directly in the SDK callback (navdata_custom_process).
