### PR TITLE
Enabling full realtime video and navdata

### DIFF
--- a/launch/ardrone_aggressive.launch
+++ b/launch/ardrone_aggressive.launch
@@ -65,6 +65,7 @@
 	<!-- Do we want to publish new-style navdata when received (true), or every time the ros-loop runs (false)? -->
 	<!-- (does not affect legacy navdata, which is always published at ros-loop rate) -->
 		<param name="fullspeed_navdata" value="true" />
+		<param name="fullspeed_video" value="true" />
 
 	<!-- Covariance Values (3x3 matrices reshaped to 1x9)-->
         <rosparam param="cov/imu_la">[0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1]</rosparam>

--- a/launch/ardrone_aggressive.launch
+++ b/launch/ardrone_aggressive.launch
@@ -64,8 +64,8 @@
 
 	<!-- Do we want to publish new-style navdata when received (true), or every time the ros-loop runs (false)? -->
 	<!-- (does not affect legacy navdata, which is always published at ros-loop rate) -->
-		<param name="fullspeed_navdata" value="true" />
-		<param name="fullspeed_video" value="true" />
+		<param name="realtime_navdata" value="true" />
+		<param name="realtime_video" value="true" />
 
 	<!-- Covariance Values (3x3 matrices reshaped to 1x9)-->
         <rosparam param="cov/imu_la">[0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1]</rosparam>

--- a/scripts/NavdataMessageDefinitionsTemplate.c
+++ b/scripts/NavdataMessageDefinitionsTemplate.c
@@ -16,7 +16,7 @@
 #endif
 
 #ifdef NAVDATA_STRUCTS_HEADER_PUBLIC
-	void PublishNavdataTypes(navdata_unpacked_t &n, ros::Time &received);
+	void PublishNavdataTypes(const navdata_unpacked_t &n, const ros::Time &received);
 #endif
 
 #ifdef NAVDATA_STRUCTS_HEADER_PRIVATE

--- a/scripts/NavdataMessageDefinitionsTemplate.c
+++ b/scripts/NavdataMessageDefinitionsTemplate.c
@@ -16,7 +16,7 @@
 #endif
 
 #ifdef NAVDATA_STRUCTS_HEADER_PUBLIC
-	void PublishNavdataTypes(navdata_unpacked_t &n);
+	void PublishNavdataTypes(navdata_unpacked_t &n, ros::Time &received);
 #endif
 
 #ifdef NAVDATA_STRUCTS_HEADER_PRIVATE
@@ -60,17 +60,15 @@
 #endif
 
 #ifdef NAVDATA_STRUCTS_SOURCE
-void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
+void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n, ros::Time &received)
 {
-	const ros::Time now = ros::Time::now();
-
 	if(initialized_navdata_publishers)
 	{
 % for item in structs:
 		if(enabled_${item['struct_name']} && pub_${item['struct_name']}.getNumSubscribers()>0)
 		{
 			${item['struct_name']}_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			${item['struct_name']}_msg.header.stamp = now;
+			${item['struct_name']}_msg.header.stamp = received;
 			${item['struct_name']}_msg.header.frame_id = droneFrameBase;
 
 % for member in item['members']:

--- a/src/NavdataMessageDefinitions.h
+++ b/src/NavdataMessageDefinitions.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifdef NAVDATA_STRUCTS_HEADER_PUBLIC
-	void PublishNavdataTypes(navdata_unpacked_t &n);
+	void PublishNavdataTypes(navdata_unpacked_t &n, ros::Time &received);
 #endif
 
 #ifdef NAVDATA_STRUCTS_HEADER_PRIVATE
@@ -378,16 +378,14 @@
 #endif
 
 #ifdef NAVDATA_STRUCTS_SOURCE
-void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
+void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n, ros::Time &received)
 {
-	const ros::Time now = ros::Time::now();
-
 	if(initialized_navdata_publishers)
 	{
 		if(enabled_navdata_demo && pub_navdata_demo.getNumSubscribers()>0)
 		{
 			navdata_demo_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_demo_msg.header.stamp = now;
+			navdata_demo_msg.header.stamp = received;
 			navdata_demo_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -502,7 +500,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_time && pub_navdata_time.getNumSubscribers()>0)
 		{
 			navdata_time_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_time_msg.header.stamp = now;
+			navdata_time_msg.header.stamp = received;
 			navdata_time_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -537,7 +535,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_raw_measures && pub_navdata_raw_measures.getNumSubscribers()>0)
 		{
 			navdata_raw_measures_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_raw_measures_msg.header.stamp = now;
+			navdata_raw_measures_msg.header.stamp = received;
 			navdata_raw_measures_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -688,7 +686,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_phys_measures && pub_navdata_phys_measures.getNumSubscribers()>0)
 		{
 			navdata_phys_measures_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_phys_measures_msg.header.stamp = now;
+			navdata_phys_measures_msg.header.stamp = received;
 			navdata_phys_measures_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -775,7 +773,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_gyros_offsets && pub_navdata_gyros_offsets.getNumSubscribers()>0)
 		{
 			navdata_gyros_offsets_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_gyros_offsets_msg.header.stamp = now;
+			navdata_gyros_offsets_msg.header.stamp = received;
 			navdata_gyros_offsets_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -812,7 +810,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_euler_angles && pub_navdata_euler_angles.getNumSubscribers()>0)
 		{
 			navdata_euler_angles_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_euler_angles_msg.header.stamp = now;
+			navdata_euler_angles_msg.header.stamp = received;
 			navdata_euler_angles_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -855,7 +853,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_references && pub_navdata_references.getNumSubscribers()>0)
 		{
 			navdata_references_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_references_msg.header.stamp = now;
+			navdata_references_msg.header.stamp = received;
 			navdata_references_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1050,7 +1048,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_trims && pub_navdata_trims.getNumSubscribers()>0)
 		{
 			navdata_trims_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_trims_msg.header.stamp = now;
+			navdata_trims_msg.header.stamp = received;
 			navdata_trims_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1101,7 +1099,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_rc_references && pub_navdata_rc_references.getNumSubscribers()>0)
 		{
 			navdata_rc_references_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_rc_references_msg.header.stamp = now;
+			navdata_rc_references_msg.header.stamp = received;
 			navdata_rc_references_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1168,7 +1166,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_pwm && pub_navdata_pwm.getNumSubscribers()>0)
 		{
 			navdata_pwm_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_pwm_msg.header.stamp = now;
+			navdata_pwm_msg.header.stamp = received;
 			navdata_pwm_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1395,7 +1393,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_altitude && pub_navdata_altitude.getNumSubscribers()>0)
 		{
 			navdata_altitude_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_altitude_msg.header.stamp = now;
+			navdata_altitude_msg.header.stamp = received;
 			navdata_altitude_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1505,7 +1503,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_vision_raw && pub_navdata_vision_raw.getNumSubscribers()>0)
 		{
 			navdata_vision_raw_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_vision_raw_msg.header.stamp = now;
+			navdata_vision_raw_msg.header.stamp = received;
 			navdata_vision_raw_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1556,7 +1554,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_vision_of && pub_navdata_vision_of.getNumSubscribers()>0)
 		{
 			navdata_vision_of_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_vision_of_msg.header.stamp = now;
+			navdata_vision_of_msg.header.stamp = received;
 			navdata_vision_of_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1603,7 +1601,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_vision && pub_navdata_vision.getNumSubscribers()>0)
 		{
 			navdata_vision_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_vision_msg.header.stamp = now;
+			navdata_vision_msg.header.stamp = received;
 			navdata_vision_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1792,7 +1790,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_vision_perf && pub_navdata_vision_perf.getNumSubscribers()>0)
 		{
 			navdata_vision_perf_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_vision_perf_msg.header.stamp = now;
+			navdata_vision_perf_msg.header.stamp = received;
 			navdata_vision_perf_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1869,7 +1867,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_trackers_send && pub_navdata_trackers_send.getNumSubscribers()>0)
 		{
 			navdata_trackers_send_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_trackers_send_msg.header.stamp = now;
+			navdata_trackers_send_msg.header.stamp = received;
 			navdata_trackers_send_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -1917,7 +1915,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_vision_detect && pub_navdata_vision_detect.getNumSubscribers()>0)
 		{
 			navdata_vision_detect_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_vision_detect_msg.header.stamp = now;
+			navdata_vision_detect_msg.header.stamp = received;
 			navdata_vision_detect_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2062,7 +2060,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_watchdog && pub_navdata_watchdog.getNumSubscribers()>0)
 		{
 			navdata_watchdog_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_watchdog_msg.header.stamp = now;
+			navdata_watchdog_msg.header.stamp = received;
 			navdata_watchdog_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2089,7 +2087,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_adc_data_frame && pub_navdata_adc_data_frame.getNumSubscribers()>0)
 		{
 			navdata_adc_data_frame_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_adc_data_frame_msg.header.stamp = now;
+			navdata_adc_data_frame_msg.header.stamp = received;
 			navdata_adc_data_frame_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2134,7 +2132,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_video_stream && pub_navdata_video_stream.getNumSubscribers()>0)
 		{
 			navdata_video_stream_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_video_stream_msg.header.stamp = now;
+			navdata_video_stream_msg.header.stamp = received;
 			navdata_video_stream_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2265,7 +2263,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_games && pub_navdata_games.getNumSubscribers()>0)
 		{
 			navdata_games_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_games_msg.header.stamp = now;
+			navdata_games_msg.header.stamp = received;
 			navdata_games_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2308,7 +2306,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_pressure_raw && pub_navdata_pressure_raw.getNumSubscribers()>0)
 		{
 			navdata_pressure_raw_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_pressure_raw_msg.header.stamp = now;
+			navdata_pressure_raw_msg.header.stamp = received;
 			navdata_pressure_raw_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2367,7 +2365,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_magneto && pub_navdata_magneto.getNumSubscribers()>0)
 		{
 			navdata_magneto_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_magneto_msg.header.stamp = now;
+			navdata_magneto_msg.header.stamp = received;
 			navdata_magneto_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2512,7 +2510,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_wind_speed && pub_navdata_wind_speed.getNumSubscribers()>0)
 		{
 			navdata_wind_speed_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_wind_speed_msg.header.stamp = now;
+			navdata_wind_speed_msg.header.stamp = received;
 			navdata_wind_speed_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2643,7 +2641,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_kalman_pressure && pub_navdata_kalman_pressure.getNumSubscribers()>0)
 		{
 			navdata_kalman_pressure_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_kalman_pressure_msg.header.stamp = now;
+			navdata_kalman_pressure_msg.header.stamp = received;
 			navdata_kalman_pressure_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2806,7 +2804,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_hdvideo_stream && pub_navdata_hdvideo_stream.getNumSubscribers()>0)
 		{
 			navdata_hdvideo_stream_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_hdvideo_stream_msg.header.stamp = now;
+			navdata_hdvideo_stream_msg.header.stamp = received;
 			navdata_hdvideo_stream_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2889,7 +2887,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_wifi && pub_navdata_wifi.getNumSubscribers()>0)
 		{
 			navdata_wifi_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_wifi_msg.header.stamp = now;
+			navdata_wifi_msg.header.stamp = received;
 			navdata_wifi_msg.header.frame_id = droneFrameBase;
 
 			{				
@@ -2924,7 +2922,7 @@ void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n)
 		if(enabled_navdata_zimmu_3000 && pub_navdata_zimmu_3000.getNumSubscribers()>0)
 		{
 			navdata_zimmu_3000_msg.drone_time = ((double)ardrone_time_to_usec(n.navdata_time.time))/1000000.0;
-			navdata_zimmu_3000_msg.header.stamp = now;
+			navdata_zimmu_3000_msg.header.stamp = received;
 			navdata_zimmu_3000_msg.header.frame_id = droneFrameBase;
 
 			{				

--- a/src/NavdataMessageDefinitions.h
+++ b/src/NavdataMessageDefinitions.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifdef NAVDATA_STRUCTS_HEADER_PUBLIC
-	void PublishNavdataTypes(navdata_unpacked_t &n, ros::Time &received);
+	void PublishNavdataTypes(const navdata_unpacked_t &n, const ros::Time &received);
 #endif
 
 #ifdef NAVDATA_STRUCTS_HEADER_PRIVATE
@@ -378,7 +378,7 @@
 #endif
 
 #ifdef NAVDATA_STRUCTS_SOURCE
-void ARDroneDriver::PublishNavdataTypes(navdata_unpacked_t &n, ros::Time &received)
+void ARDroneDriver::PublishNavdataTypes(const navdata_unpacked_t &n, const ros::Time &received)
 {
 	if(initialized_navdata_publishers)
 	{

--- a/src/ardrone_driver.cpp
+++ b/src/ardrone_driver.cpp
@@ -139,8 +139,8 @@ void ARDroneDriver::run()
                 ROS_INFO("Navdata Publish Settings:");
                 ROS_INFO("    Legacy Mode: %s", enabled_legacy_navdata ? "On" : "Off"); //Bug: This is being inited after in the NavdataMessage*.h
                 ROS_INFO("    ROS Loop Rate: %d", looprate);
-                ROS_INFO("    Instant New Navdata Publish: %s", fullspeed_navdata ? "On" : "Off");
-                ROS_INFO("    Instant New Video Publish: %s", fullspeed_video ? "On" : "Off");
+                ROS_INFO("    Instant New Navdata Publish: %s", realtime_navdata ? "On" : "Off");
+                ROS_INFO("    Instant New Video Publish: %s", realtime_video ? "On" : "Off");
                 ROS_INFO("    Drone Send Speed: %s", ardrone_application_default_config.navdata_demo==0 ? "200Hz (navdata_demo=0)" : "15Hz (navdata_demo=1)");
                 // TODO: Enabled Navdata Demo
                 vp_os_mutex_unlock(&navdata_lock);
@@ -150,7 +150,7 @@ void ARDroneDriver::run()
                 }
             }
         } else {
-            if(!fullspeed_video)
+            if(!realtime_video)
             {
                 vp_os_mutex_lock(&video_lock);
                 copy_current_frame_id = current_frame_id;
@@ -162,7 +162,7 @@ void ARDroneDriver::run()
                 }
             }
 
-            if(!fullspeed_navdata)
+            if(!realtime_navdata)
             {
                 vp_os_mutex_lock(&navdata_lock);
                 copy_current_navdata_id = current_navdata_id;
@@ -383,9 +383,9 @@ void ARDroneDriver::publish_video()
         image_msg.step = D1_STREAM_WIDTH*3;
         image_msg.data.resize(D1_STREAM_WIDTH*D1_STREAM_HEIGHT*3);
 
-        if(!fullspeed_video) vp_os_mutex_lock(&video_lock);
+        if(!realtime_video) vp_os_mutex_lock(&video_lock);
         std::copy(buffer, buffer+(D1_STREAM_WIDTH*D1_STREAM_HEIGHT*3), image_msg.data.begin());
-        if(!fullspeed_video) vp_os_mutex_unlock(&video_lock);
+        if(!realtime_video) vp_os_mutex_unlock(&video_lock);
 
         if (cam_state == ZAP_CHANNEL_HORI)
         {
@@ -411,14 +411,14 @@ void ARDroneDriver::publish_video()
             image_msg.data.clear();
             image_msg.data.resize(D1_VERTSTREAM_WIDTH*D1_VERTSTREAM_HEIGHT*3);
             _it = image_msg.data.begin();
-            if(!fullspeed_video) vp_os_mutex_lock(&video_lock);
+            if(!realtime_video) vp_os_mutex_lock(&video_lock);
             for (int row = 0; row < D1_VERTSTREAM_HEIGHT ; row++)
             {
                 int _b = row * D1_STREAM_WIDTH * 3;
                 int _e = _b + image_msg.step;
                 _it = std::copy(buffer + _b, buffer + _e, _it);
             }
-            if(!fullspeed_video) vp_os_mutex_unlock(&video_lock);
+            if(!realtime_video) vp_os_mutex_unlock(&video_lock);
 
             cinfo_msg_vert.width = D1_VERTSTREAM_WIDTH;
             cinfo_msg_vert.height = D1_VERTSTREAM_HEIGHT;
@@ -441,14 +441,14 @@ void ARDroneDriver::publish_video()
             image_msg.data.clear();
             image_msg.data.resize((D1_STREAM_WIDTH - D1_MODE2_PIP_WIDTH)*D1_STREAM_HEIGHT*3);
             _it = image_msg.data.begin();
-            if(!fullspeed_video) vp_os_mutex_lock(&video_lock);
+            if(!realtime_video) vp_os_mutex_lock(&video_lock);
             for (int row = 0; row < D1_STREAM_HEIGHT; row++)
             {
                 int _b = (row * D1_STREAM_WIDTH * 3) + (D1_MODE2_PIP_WIDTH * 3);
                 int _e = _b + image_msg.step;
                 _it = std::copy(buffer + _b, buffer + _e, _it);
             }
-            if(!fullspeed_video) vp_os_mutex_unlock(&video_lock);
+            if(!realtime_video) vp_os_mutex_unlock(&video_lock);
 
             cinfo_msg_hori.width = D1_STREAM_WIDTH - D1_MODE2_PIP_WIDTH;
             cinfo_msg_hori.height = D1_STREAM_HEIGHT;
@@ -463,14 +463,14 @@ void ARDroneDriver::publish_video()
             image_msg.data.clear();
             image_msg.data.resize(D1_MODE2_PIP_WIDTH * D1_MODE2_PIP_HEIGHT * 3);
             _it = image_msg.data.begin();
-            if(!fullspeed_video) vp_os_mutex_lock(&video_lock);
+            if(!realtime_video) vp_os_mutex_lock(&video_lock);
             for (int row = 0; row < D1_MODE2_PIP_HEIGHT; row++)
             {
                 int _b = row * D1_STREAM_WIDTH * 3;
                 int _e = _b + image_msg.step;
                 _it = std::copy(buffer + _b, buffer + _e, _it);
             }
-            if(!fullspeed_video) vp_os_mutex_unlock(&video_lock);
+            if(!realtime_video) vp_os_mutex_unlock(&video_lock);
 
             cinfo_msg_vert.width = D1_MODE2_PIP_WIDTH;
             cinfo_msg_vert.height = D1_MODE2_PIP_HEIGHT;
@@ -496,9 +496,9 @@ void ARDroneDriver::publish_video()
             {
                 int _b = (row * (D1_STREAM_WIDTH * 3)) + (D1_MODE3_PIP_WIDTH * 3);
                 int _e = _b + image_msg.step;
-                if(!fullspeed_video) vp_os_mutex_lock(&video_lock);
+                if(!realtime_video) vp_os_mutex_lock(&video_lock);
                 _it = std::copy(buffer + _b, buffer + _e, _it);
-                if(!fullspeed_video) vp_os_mutex_unlock(&video_lock);
+                if(!realtime_video) vp_os_mutex_unlock(&video_lock);
             }
 
             cinfo_msg_vert.width = D1_VERTSTREAM_WIDTH - D1_MODE3_PIP_WIDTH;
@@ -514,13 +514,13 @@ void ARDroneDriver::publish_video()
             image_msg.data.clear();
             image_msg.data.resize(D1_MODE3_PIP_WIDTH * D1_MODE3_PIP_HEIGHT * 3);
             _it = image_msg.data.begin();
-            if(!fullspeed_video) vp_os_mutex_lock(&video_lock);
+            if(!realtime_video) vp_os_mutex_lock(&video_lock);
             for (int row = 0; row < D1_MODE3_PIP_HEIGHT; row++)
             {
                 int _b = row * D1_STREAM_WIDTH * 3;
                 int _e = _b + image_msg.step;
                 _it = std::copy(buffer + _b, buffer + _e, _it);
-            }if(!fullspeed_video) vp_os_mutex_unlock(&video_lock);
+            }if(!realtime_video) vp_os_mutex_unlock(&video_lock);
 
             cinfo_msg_hori.width = D1_MODE3_PIP_WIDTH;
             cinfo_msg_hori.height = D1_MODE3_PIP_HEIGHT;
@@ -561,9 +561,9 @@ void ARDroneDriver::publish_video()
         image_msg.is_bigendian = false;
         image_msg.step = D2_STREAM_WIDTH*3;
         image_msg.data.resize(D2_STREAM_WIDTH*D2_STREAM_HEIGHT*3);
-        if(!fullspeed_video) vp_os_mutex_lock(&video_lock);
+        if(!realtime_video) vp_os_mutex_lock(&video_lock);
         std::copy(buffer, buffer+(D2_STREAM_WIDTH*D2_STREAM_HEIGHT*3), image_msg.data.begin());
-        if(!fullspeed_video) vp_os_mutex_unlock(&video_lock);
+        if(!realtime_video) vp_os_mutex_unlock(&video_lock);
         // We only put the width and height in here.
 
 

--- a/src/ardrone_driver.h
+++ b/src/ardrone_driver.h
@@ -112,6 +112,7 @@ private:
 
     // Navdata copy
     navdata_unpacked_t navdata_raw;
+    ros::Time navdata_receive_time;
 
     // Load auto-generated declarations for full navdata
     #define NAVDATA_STRUCTS_HEADER_PRIVATE

--- a/src/ardrone_driver.h
+++ b/src/ardrone_driver.h
@@ -1,6 +1,7 @@
 #ifndef _ARDRONE_DRIVER_H_
 #define _ARDRONE_DRIVER_H_
 
+class ARDroneDriver;
 #include <ros/ros.h>
 #include <image_transport/image_transport.h>
 #include <tf/transform_broadcaster.h>
@@ -52,8 +53,8 @@ public:
     #include "NavdataMessageDefinitions.h"
     #undef NAVDATA_STRUCTS_HEADER_PUBLIC
 
+    void publish_video();
 private:
-	void publish_video();
 	void publish_navdata();
     void publish_tf();
     bool readCovParams(std::string param_name, boost::array<double, 9> &cov_array);

--- a/src/ardrone_driver.h
+++ b/src/ardrone_driver.h
@@ -2,6 +2,7 @@
 #define _ARDRONE_DRIVER_H_
 
 class ARDroneDriver;
+
 #include <ros/ros.h>
 #include <image_transport/image_transport.h>
 #include <tf/transform_broadcaster.h>
@@ -54,8 +55,9 @@ public:
     #undef NAVDATA_STRUCTS_HEADER_PUBLIC
 
     void publish_video();
+    void publish_navdata(navdata_unpacked_t &navdata_raw, const ros::Time &navdata_receive_time);
+
 private:
-	void publish_navdata();
     void publish_tf();
     bool readCovParams(std::string param_name, boost::array<double, 9> &cov_array);
     double calcAverage(std::vector<double> &vec);
@@ -110,10 +112,6 @@ private:
 
     bool inited;
     std::string droneFrameId;
-
-    // Navdata copy
-    navdata_unpacked_t navdata_raw;
-    ros::Time navdata_receive_time;
 
     // Load auto-generated declarations for full navdata
     #define NAVDATA_STRUCTS_HEADER_PRIVATE

--- a/src/ardrone_sdk.cpp
+++ b/src/ardrone_sdk.cpp
@@ -1,9 +1,10 @@
 #include "ardrone_sdk.h"
 #include "video.h"
 #include "teleop_twist.h"
-#include "ardrone_driver.h"
+
 
 navdata_unpacked_t shared_raw_navdata;
+ros::Time shared_navdata_receive_time;
 
 vp_os_mutex_t navdata_lock;
 vp_os_mutex_t video_lock;
@@ -226,9 +227,11 @@ extern "C" {
         vp_os_mutex_lock(&navdata_lock);
         // TODO: This is expensive, too (1908 Bytes)!
         shared_raw_navdata = *pnd;
+        shared_navdata_receive_time = ros::Time::now();
+
         if(fullspeed_navdata)
         {
-            rosDriver->PublishNavdataTypes(shared_raw_navdata); //if we're publishing navdata at full speed, publish!
+            rosDriver->PublishNavdataTypes(shared_raw_navdata,shared_navdata_receive_time); //if we're publishing navdata at full speed, publish!
         }
         current_navdata_id++;
         vp_os_mutex_unlock(&navdata_lock);

--- a/src/ardrone_sdk.cpp
+++ b/src/ardrone_sdk.cpp
@@ -16,6 +16,7 @@ ARDroneDriver* rosDriver;
 
 int32_t looprate;
 bool fullspeed_navdata;
+bool fullspeed_video;
 
 int32_t should_exit;
 
@@ -61,6 +62,7 @@ extern "C" {
 
         ros::param::param("~looprate",looprate,50);
         ros::param::param("~fullspeed_navdata",fullspeed_navdata,false);
+        ros::param::param("~fullspeed_video",fullspeed_video,false);
 
         // SET SOME NON-STANDARD DEFAULT VALUES FOR THE DRIVER
         // THESE CAN BE OVERWRITTEN BY ROS PARAMETERS (below)

--- a/src/ardrone_sdk.cpp
+++ b/src/ardrone_sdk.cpp
@@ -15,8 +15,8 @@ long int current_navdata_id = 0;
 ARDroneDriver* rosDriver;
 
 int32_t looprate;
-bool fullspeed_navdata;
-bool fullspeed_video;
+bool realtime_navdata;
+bool realtime_video;
 
 int32_t should_exit;
 
@@ -61,8 +61,8 @@ extern "C" {
         }
 
         ros::param::param("~looprate",looprate,50);
-        ros::param::param("~fullspeed_navdata",fullspeed_navdata,false);
-        ros::param::param("~fullspeed_video",fullspeed_video,false);
+        ros::param::param("~realtime_navdata",realtime_navdata,false);
+        ros::param::param("~realtime_video",realtime_video,false);
 
         // SET SOME NON-STANDARD DEFAULT VALUES FOR THE DRIVER
         // THESE CAN BE OVERWRITTEN BY ROS PARAMETERS (below)
@@ -230,7 +230,7 @@ extern "C" {
         shared_navdata_receive_time = ros::Time::now();
         shared_raw_navdata = (navdata_unpacked_t*)pnd;
 
-        if(fullspeed_navdata)
+        if(realtime_navdata)
         {
             rosDriver->PublishNavdataTypes(*shared_raw_navdata, shared_navdata_receive_time); //if we're publishing navdata at full speed, publish!
             rosDriver->publish_navdata(*shared_raw_navdata, shared_navdata_receive_time);

--- a/src/ardrone_sdk.h
+++ b/src/ardrone_sdk.h
@@ -43,9 +43,11 @@ extern "C" {
 extern video_decoder_config_t vec;
 }
 
+#include "ardrone_driver.h"
 
 #define NB_DRIVER_POST_STAGES   10
 extern navdata_unpacked_t shared_raw_navdata;
+extern ros::Time shared_navdata_receive_time;
 
 extern vp_os_mutex_t navdata_lock;
 extern vp_os_mutex_t video_lock;

--- a/src/ardrone_sdk.h
+++ b/src/ardrone_sdk.h
@@ -57,8 +57,8 @@ extern vp_os_mutex_t video_lock;
 extern vp_os_mutex_t twist_lock;
 
 extern int32_t looprate;
-extern bool fullspeed_navdata;
-extern bool fullspeed_video;
+extern bool realtime_navdata;
+extern bool realtime_video;
 
 extern int32_t should_exit;
 

--- a/src/ardrone_sdk.h
+++ b/src/ardrone_sdk.h
@@ -47,6 +47,7 @@ extern video_decoder_config_t vec;
 
 #define NB_DRIVER_POST_STAGES   10
 extern navdata_unpacked_t shared_raw_navdata;
+extern ARDroneDriver *rosDriver;
 extern ros::Time shared_navdata_receive_time;
 
 extern vp_os_mutex_t navdata_lock;
@@ -55,6 +56,7 @@ extern vp_os_mutex_t twist_lock;
 
 extern int32_t looprate;
 extern bool fullspeed_navdata;
+extern bool fullspeed_video;
 
 extern int32_t should_exit;
 

--- a/src/ardrone_sdk.h
+++ b/src/ardrone_sdk.h
@@ -46,8 +46,10 @@ extern video_decoder_config_t vec;
 #include "ardrone_driver.h"
 
 #define NB_DRIVER_POST_STAGES   10
-extern navdata_unpacked_t shared_raw_navdata;
+
 extern ARDroneDriver *rosDriver;
+
+extern navdata_unpacked_t *shared_raw_navdata;
 extern ros::Time shared_navdata_receive_time;
 
 extern vp_os_mutex_t navdata_lock;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -18,7 +18,7 @@ extern "C" C_RESULT export_stage_transform( void *cfg, vp_api_io_data_t *in, vp_
     vp_os_mutex_lock(&video_lock);
 	memcpy(buffer, in->buffers[0], in->size);
     current_frame_id++;
-    if(fullspeed_video)
+    if(realtime_video)
     {
     	rosDriver->publish_video();
     }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -18,6 +18,10 @@ extern "C" C_RESULT export_stage_transform( void *cfg, vp_api_io_data_t *in, vp_
     vp_os_mutex_lock(&video_lock);
 	memcpy(buffer, in->buffers[0], in->size);
     current_frame_id++;
+    if(fullspeed_video)
+    {
+    	rosDriver->publish_video();
+    }
     vp_os_mutex_unlock(&video_lock);
 //    vp_os_mutex_unlock(&video_update_lock);	
  	return (SUCCESS);

--- a/src/video.h
+++ b/src/video.h
@@ -2,6 +2,7 @@
 #define _VIDEO_H_
 
 #include "ardrone_sdk.h"
+#include "ardrone_driver.h"
 
 // The maximum memory allocation
 #define MAX_STREAM_WIDTH 640


### PR DESCRIPTION
This branch is a further extension of the functionality in #43. In this branch I have enabled realtime publishing of /ardrone/navdata,mag,imu topics as well. Furthermore, this branch allows realtime publishing of video frames. The branch also includes speed improvements for the navdata pipeline. I haven't considered speed of the video pipeline as I have no idea what it's doing (I never use video), and it is fairly slow (30Hz) anyway.

However, making the changes in the above branch has indicated that the current architecture doesn't really fit the future direction of the driver, so perhaps we need to consider a few architectural changes so that making realtime stuff work isn't such a hack...

I suggest we continue this discussion in #42.
