### PR TITLE
Turn on and off USB stick recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 	- [Flight Animations ](#flight-animations-new) :new:
 	- [IMU Calibration](#imu-calibration)
 	- [Flat Trim](#flat-trim)
+	- [Record to USB Stick](#record-usb)
 - [Parameters](#parameters)
 	- [AR-Drone Specific Parameters](#ar-drone-specific-parameters)
 	- [Other Parameters](#other-parameters)
@@ -276,6 +277,10 @@ If `do_imu_caliberation` parameter is set to true, calling `ardrone/imu_recalib`
 ### Flat Trim
 
 Calling `ardrone/flattrim` service without any parameter will send a "Flat Trim" request to AR-Drone to re-calibrate its rotation estimates assuming that it is on a flat surface. Do not call this service while Drone is flying or while the drone is not actually on a flat surface.
+
+### Record to USB Stick
+
+Calling `ardrone/setrecord` service will enable and disable recording to the USB stick. The service takes a simple `1` to enable or `0` to disable. So you can turn on recording to the USB stick with `rosservice call /ardrone/setrecord 1`
 
 ## Parameters
 

--- a/src/ardrone_driver.cpp
+++ b/src/ardrone_driver.cpp
@@ -27,6 +27,7 @@ ARDroneDriver::ARDroneDriver()
     setLedAnimation_service = node_handle.advertiseService("ardrone/setledanimation", setLedAnimationCallback);
     flatTrim_service = node_handle.advertiseService("ardrone/flattrim", flatTrimCallback);
     setFlightAnimation_service = node_handle.advertiseService("ardrone/setflightanimation", setFlightAnimationCallback);
+    setRecord_service = node_handle.advertiseService("ardrone/setrecord", setRecordCallback );
 
     /*
         To be honest, I am not sure why advertising a service using class members should be this complicated!

--- a/src/ardrone_driver.h
+++ b/src/ardrone_driver.h
@@ -90,6 +90,7 @@ private:
     ros::ServiceServer imuReCalib_service;
     ros::ServiceServer flatTrim_service;
     ros::ServiceServer setFlightAnimation_service;
+    ros::ServiceServer setRecord_service;
 	
 	/*
 	 * Orange Green : 1

--- a/src/teleop_twist.h
+++ b/src/teleop_twist.h
@@ -8,6 +8,7 @@
 #include <ardrone_autonomy/CamSelect.h>
 #include <ardrone_autonomy/LedAnim.h>
 #include <ardrone_autonomy/FlightAnim.h>
+#include <ardrone_autonomy/RecordEnable.h>
 
 #define _EPS 1.0e-6 
 
@@ -24,6 +25,7 @@ bool toggleCamCallback(std_srvs::Empty::Request& request, std_srvs::Empty::Respo
 bool setLedAnimationCallback(ardrone_autonomy::LedAnim::Request& request, ardrone_autonomy::LedAnim::Response& response);
 bool flatTrimCallback(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 bool setFlightAnimationCallback(ardrone_autonomy::FlightAnim::Request& request, ardrone_autonomy::FlightAnim::Response& response);
+bool setRecordCallback(ardrone_autonomy::RecordEnable::Request &request, ardrone_autonomy::RecordEnable::Response& response);
 
 //All global drone configs that should be sent on init
 

--- a/srv/RecordEnable.srv
+++ b/srv/RecordEnable.srv
@@ -1,0 +1,3 @@
+bool enable
+---
+bool result


### PR DESCRIPTION
I had some fun, rooting my phone and running tcpdump to figure out what it was doing to turn on and off usb stick recording. Turns out that it sends a userbox cmd to turn on and off recording, while also changing the codec.
