### PR TITLE
added /ardrone/odometry topic and corresponding "odom" tf_frame

### DIFF
--- a/scripts/NavdataMessageDefinitionsTemplate.c
+++ b/scripts/NavdataMessageDefinitionsTemplate.c
@@ -42,6 +42,7 @@
 			navdata_pub = node_handle.advertise<ardrone_autonomy::Navdata>("ardrone/navdata", 25);
 			imu_pub = node_handle.advertise<sensor_msgs::Imu>("ardrone/imu", 25);
 			mag_pub = node_handle.advertise<geometry_msgs::Vector3Stamped>("ardrone/mag", 25);
+			odo_pub = node_handle.advertise<nav_msgs::Odometry>("ardrone/odometry", 25);
 		}
 
 		//-------------------------

--- a/src/NavdataMessageDefinitions.h
+++ b/src/NavdataMessageDefinitions.h
@@ -146,6 +146,7 @@
 			navdata_pub = node_handle.advertise<ardrone_autonomy::Navdata>("ardrone/navdata", 25);
 			imu_pub = node_handle.advertise<sensor_msgs::Imu>("ardrone/imu", 25);
 			mag_pub = node_handle.advertise<geometry_msgs::Vector3Stamped>("ardrone/mag", 25);
+			odo_pub = node_handle.advertise<nav_msgs::Odometry>("ardrone/odometry", 25);
 		}
 
 		//-------------------------

--- a/src/ardrone_driver.cpp
+++ b/src/ardrone_driver.cpp
@@ -108,6 +108,8 @@ ARDroneDriver::ARDroneDriver()
         tf_base_bottom.child_frame_id_.swap(tf_base_bottom.frame_id_);
     }
 
+    // reset odometry
+    odometry[0] = odometry[1] = 0;
 }
 
 ARDroneDriver::~ARDroneDriver()
@@ -182,7 +184,8 @@ void ARDroneDriver::run()
                     vp_os_mutex_unlock(&navdata_lock);
 
                     PublishNavdataTypes(navdata_raw, navdata_receive_time); // This function is defined in the template NavdataMessageDefinitions.h template file
-                    publish_navdata(navdata_raw, navdata_receive_time);                
+                    publish_navdata(navdata_raw, navdata_receive_time);
+                    publish_odometry(navdata_raw, navdata_receive_time);
                 }
             }
             if (freq_dev == 0) publish_tf();
@@ -771,8 +774,40 @@ void ARDroneDriver::publish_tf()
 {
     tf_base_front.stamp_ = ros::Time::now();
     tf_base_bottom.stamp_ = ros::Time::now();
+    tf_odom.stamp_ = ros::Time::now();
     tf_broad.sendTransform(tf_base_front);
     tf_broad.sendTransform(tf_base_bottom);
+    tf_broad.sendTransform(tf_odom);
+}
+
+void ARDroneDriver::publish_odometry(navdata_unpacked_t &navdata_raw, const ros::Time &navdata_receive_time)
+{
+  if (last_receive_time.isValid()) {
+    double delta_t = (navdata_receive_time - last_receive_time).toSec();
+    odometry[0] += ((cos((navdata_raw.navdata_demo.psi/180000) * M_PI) * navdata_raw.navdata_demo.vx - sin((navdata_raw.navdata_demo.psi/180000) * M_PI) * -navdata_raw.navdata_demo.vy) * delta_t) / 1000.0;
+    odometry[1] += ((sin((navdata_raw.navdata_demo.psi/180000) * M_PI) * navdata_raw.navdata_demo.vx + cos((navdata_raw.navdata_demo.psi/180000) * M_PI) * -navdata_raw.navdata_demo.vy) * delta_t) / 1000.0;
+  }
+  last_receive_time = navdata_receive_time;
+
+  nav_msgs::Odometry odo_msg;
+  odo_msg.header.stamp = navdata_receive_time;
+  odo_msg.header.frame_id = "odom";
+  odo_msg.child_frame_id = droneFrameBase;
+  odo_msg.pose.pose.position.x = odometry[0];
+  odo_msg.pose.pose.position.y = odometry[1];
+  odo_msg.pose.pose.position.z = navdata_raw.navdata_demo.altitude / 1000;
+  odo_msg.pose.pose.orientation = tf::createQuaternionMsgFromRollPitchYaw(navdata_raw.navdata_demo.phi / 180000.0 * M_PI, -navdata_raw.navdata_demo.theta / 180000.0 * M_PI, -navdata_raw.navdata_demo.psi / 180000.0 * M_PI);
+  odo_pub.publish(odo_msg);
+
+  tf::Vector3 t;
+  tf::pointMsgToTF(odo_msg.pose.pose.position, t);
+  tf::Quaternion q;
+  tf::quaternionMsgToTF(odo_msg.pose.pose.orientation, q);
+  
+  tf_odom.frame_id_ = "odom";
+  tf_odom.child_frame_id_ = droneFrameBase;
+  tf_odom.setOrigin(t);
+  tf_odom.setRotation(q);
 }
 
 bool ARDroneDriver::imuReCalibCallback(std_srvs::Empty::Request &request, std_srvs::Empty::Response &response)

--- a/src/ardrone_driver.cpp
+++ b/src/ardrone_driver.cpp
@@ -793,10 +793,16 @@ void ARDroneDriver::publish_odometry(navdata_unpacked_t &navdata_raw, const ros:
   odo_msg.header.stamp = navdata_receive_time;
   odo_msg.header.frame_id = "odom";
   odo_msg.child_frame_id = droneFrameBase;
+
   odo_msg.pose.pose.position.x = odometry[0];
   odo_msg.pose.pose.position.y = odometry[1];
   odo_msg.pose.pose.position.z = navdata_raw.navdata_demo.altitude / 1000;
   odo_msg.pose.pose.orientation = tf::createQuaternionMsgFromRollPitchYaw(navdata_raw.navdata_demo.phi / 180000.0 * M_PI, -navdata_raw.navdata_demo.theta / 180000.0 * M_PI, -navdata_raw.navdata_demo.psi / 180000.0 * M_PI);
+
+  odo_msg.twist.twist.linear.x = navdata_raw.navdata_demo.vx / 1000.0;
+  odo_msg.twist.twist.linear.y = -navdata_raw.navdata_demo.vy / 1000.0;
+  odo_msg.twist.twist.linear.z = -navdata_raw.navdata_demo.vz / 1000.0;
+  
   odo_pub.publish(odo_msg);
 
   tf::Vector3 t;

--- a/src/ardrone_driver.h
+++ b/src/ardrone_driver.h
@@ -11,6 +11,7 @@ class ARDroneDriver;
 #include <sensor_msgs/Imu.h>
 #include <geometry_msgs/Vector3Stamped.h>
 #include <std_srvs/Empty.h>
+#include <nav_msgs/Odometry.h>
 #include <ardrone_autonomy/Navdata.h>
 #include "ardrone_sdk.h"
 #include <vector>
@@ -56,6 +57,7 @@ public:
 
     void publish_video();
     void publish_navdata(navdata_unpacked_t &navdata_raw, const ros::Time &navdata_receive_time);
+    void publish_odometry(navdata_unpacked_t &navdata_raw, const ros::Time &navdata_receive_time);
 
 private:
     void publish_tf();
@@ -80,6 +82,7 @@ private:
     ros::Publisher navdata_pub;
     ros::Publisher imu_pub;
     ros::Publisher mag_pub;
+    ros::Publisher odo_pub;
 
     tf::TransformBroadcaster tf_broad;
 
@@ -126,7 +129,7 @@ private:
      */
     std::string droneFrameBase, droneFrameIMU, droneFrameFrontCam, droneFrameBottomCam;
     int drone_root_frame;
-    tf::StampedTransform tf_base_front, tf_base_bottom;
+    tf::StampedTransform tf_base_front, tf_base_bottom, tf_odom;
 
     // Huge part of IMU message is constant, let's fill'em once.
     sensor_msgs::Imu imu_msg;
@@ -144,6 +147,9 @@ private:
     std::vector< std::vector<double> > gyro_samples;
     std::vector< std::vector<double> > vel_samples;
 
+    // odometry (x,y)
+    ros::Time last_receive_time;
+    double odometry[2];
 };
 
 #endif

--- a/src/ardrone_sdk.cpp
+++ b/src/ardrone_sdk.cpp
@@ -234,6 +234,7 @@ extern "C" {
         {
             rosDriver->PublishNavdataTypes(*shared_raw_navdata, shared_navdata_receive_time); //if we're publishing navdata at full speed, publish!
             rosDriver->publish_navdata(*shared_raw_navdata, shared_navdata_receive_time);
+            rosDriver->publish_odometry(*shared_raw_navdata, shared_navdata_receive_time);
         }
 
         current_navdata_id++;


### PR DESCRIPTION
I've added X,Y odometry computation by accumulating instant linear velocities and absolute angles as extracted from navdata. The Z value (altitude) is taken directly from navdata. The orientation is also obtained from absolute angles. All values are reported in meters and radians.

This information is published in /ardrone/odometry (nav_msgs::Odometry) and as a TF frame with name "odom" (parent of base frame).

There is one catch, though: the accumulation of x and y is performed after every navdata is published. This implies that, if not using realtime_navdata, accumulation will not be performed for every navdata packet received and quality will suffer. It would be ideal to move this accumulation to the navdata receving thread, but in case realtime_navdata is not enabled I would need to protect this from concurrent modifications between threads.
