### PR TITLE
video timestamp is now saved on reception, same as with navdata; also fi...

### DIFF
--- a/src/ardrone_driver.cpp
+++ b/src/ardrone_driver.cpp
@@ -364,7 +364,6 @@ void ARDroneDriver::publish_video()
         sensor_msgs::Image image_msg;
         sensor_msgs::Image::_data_type::iterator _it;
 
-        image_msg.header.stamp = ros::Time::now();
         if ((cam_state == ZAP_CHANNEL_HORI) || (cam_state == ZAP_CHANNEL_LARGE_HORI_SMALL_VERT))
         {
             image_msg.header.frame_id = droneFrameFrontCam;
@@ -386,8 +385,12 @@ void ARDroneDriver::publish_video()
         image_msg.data.resize(D1_STREAM_WIDTH*D1_STREAM_HEIGHT*3);
 
         if(!realtime_video) vp_os_mutex_lock(&video_lock);
+        image_msg.header.stamp = shared_video_receive_time;
         std::copy(buffer, buffer+(D1_STREAM_WIDTH*D1_STREAM_HEIGHT*3), image_msg.data.begin());
         if(!realtime_video) vp_os_mutex_unlock(&video_lock);
+
+        cinfo_msg_hori.header.stamp = image_msg.header.stamp; 
+        cinfo_msg_vert.header.stamp = image_msg.header.stamp;
 
         if (cam_state == ZAP_CHANNEL_HORI)
         {
@@ -540,10 +543,6 @@ void ARDroneDriver::publish_video()
         sensor_msgs::Image image_msg;        
         sensor_msgs::Image::_data_type::iterator _it;
 
-        image_msg.header.stamp = ros::Time::now();
-        cinfo_msg_hori.header.stamp = image_msg.header.stamp; 
-        cinfo_msg_vert.header.stamp = image_msg.header.stamp; 
-
         if (cam_state == ZAP_CHANNEL_HORI)
         {
             image_msg.header.frame_id = droneFrameFrontCam;
@@ -564,10 +563,13 @@ void ARDroneDriver::publish_video()
         image_msg.step = D2_STREAM_WIDTH*3;
         image_msg.data.resize(D2_STREAM_WIDTH*D2_STREAM_HEIGHT*3);
         if(!realtime_video) vp_os_mutex_lock(&video_lock);
+        image_msg.header.stamp = shared_video_receive_time;
         std::copy(buffer, buffer+(D2_STREAM_WIDTH*D2_STREAM_HEIGHT*3), image_msg.data.begin());
         if(!realtime_video) vp_os_mutex_unlock(&video_lock);
         // We only put the width and height in here.
 
+        cinfo_msg_hori.header.stamp = image_msg.header.stamp; 
+        cinfo_msg_vert.header.stamp = image_msg.header.stamp;
 
         if (cam_state == ZAP_CHANNEL_HORI)
         {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -5,6 +5,7 @@
 
 unsigned char buffer[MAX_STREAM_WIDTH * MAX_STREAM_HEIGHT * 3];
 long int current_frame_id = 0;
+ros::Time shared_video_receive_time;
 
 extern "C" C_RESULT export_stage_open( void *cfg, vp_api_io_data_t *in, vp_api_io_data_t *out)
 {
@@ -16,6 +17,7 @@ extern "C" C_RESULT export_stage_transform( void *cfg, vp_api_io_data_t *in, vp_
 //    PRINT("In Transform before copy\n");
 //        printf("The size of buffer is %d\n", in->size);
     vp_os_mutex_lock(&video_lock);
+    shared_video_receive_time = ros::Time::now();
 	memcpy(buffer, in->buffers[0], in->size);
     current_frame_id++;
     if(realtime_video)

--- a/src/video.h
+++ b/src/video.h
@@ -38,6 +38,7 @@ extern const vp_api_stage_funcs_t vp_stages_export_funcs;
 extern unsigned char buffer[]; // size STREAM_WIDTH * STREAM_HEIGHT * 3
 extern long int current_frame_id; // this will be incremented for every frame
 extern long int current_navdata_id;
+extern ros::Time shared_video_receive_time;
 
 #endif
 


### PR DESCRIPTION
I've found at by looking at the code of the driver (and while looking into timing issues in the reception of messages in my code) that, in contrast to how navdata is published (where there is a navdata_reception_time in the receiver thread), the video thread in video.cpp does not store the reception time. 
I've made this simple modification which should improve timestamp precision a bit. 

On the other hand, it seems that the cinfo stamps were not matched against the image stamp in drone v1. I've made this modification also (lines 392-394).

One question: why is the video buffer copied (for both drone versions) before the if that checks which camera needs to be copied? In case the selected camera is the vertical one (for example), to me it looks like there will be two copies of the video buffer (were the second overrides the first).
