### PR TITLE
Add bad GENERIC_TARGET_LIBRARY workaround

### DIFF
--- a/ardrone_lib.patch
+++ b/ardrone_lib.patch
@@ -108,3 +108,16 @@ index 0000000..2ad03a2
 +install:
 +	mkdir -p ${INSTALL_PREFIX}
 +	find $(SDK_PATH)/Soft/Build -type f -name '*.a' -exec cp '{}' ${INSTALL_PREFIX} \;
+--- a/ardrone-sdk-stripped-2.0.1/ARDroneLib/VP_SDK/Build/lib.makefile
++++ b/ardrone-sdk-stripped-2.0.1-patched/ARDroneLib/VP_SDK/Build/lib.makefile
+@@ -11,7 +11,9 @@
+ include common.makefile
+
+ GENERIC_LIBRARY_TARGET_DIR=$(LIB_TARGET_DIR)
++ifneq ($(GENERIC_TARGET_LIBRARY),)
+ GENERIC_TARGET_LIBRARY:=$(GENERIC_LIBRARY_TARGET_DIR)/$(GENERIC_TARGET_LIBRARY)
++endif
+
+ export GENERIC_TARGET_LIBRARY
+ export GENERIC_LIBRARY_TARGET_DIR=$(LIB_TARGET_DIR)
+ 


### PR DESCRIPTION
This bug is preventing builds on Fedora.

What is happening, is that `GENERIC_TARGET_LIBRARY` is empty and `lib.makefile` prefixes that with `$(GENERIC_LIBRARY_TARGET_DIR)`, which `generic.makefile` then tries to build as a library target.

Obviously this fails, because `GENERIC_TARGET_LIBRARY` is a path to a folder.

I couldn't tell you why this isn't happening on other distros, but I tested the fix on Ubuntu 12.04 and it seemed to not cause a regression.
