### PR TITLE
Added custom network port specification

### DIFF
--- a/ardrone_lib.patch
+++ b/ardrone_lib.patch
@@ -11,8 +11,39 @@ index 0b96558..0c101a0 100644
  	$(SILENT_MAKE)echo "Done"
  endif
  endif
+diff --git a/ARDroneLib/Soft/Common/config.h b/ARDroneLib/Soft/Common/config.h
+index ba83536..51fa71b 100644
+--- a/ARDroneLib/Soft/Common/config.h
++++ b/ARDroneLib/Soft/Common/config.h
+@@ -86,15 +86,17 @@
+ 
+ #define WIFI_PASSKEY            "9F1C3EE11CBA230B27BF1C1B6F"
+ 
+-#define FTP_PORT				5551
+-#define AUTH_PORT				5552
+-#define VIDEO_RECORDER_PORT     5553
+-#define NAVDATA_PORT            5554
+-#define VIDEO_PORT              5555
+-#define AT_PORT                 5556
+-#define RAW_CAPTURE_PORT        5557
+-#define PRINTF_PORT             5558
+-#define CONTROL_PORT            5559
++// Replace constants with variables (see ../Lib/ardrone_tool/ardrone_tool.*)
++// Using unconvential all-caps to minimize impact on rest of code
++extern unsigned short FTP_PORT;
++extern unsigned short AUTH_PORT;
++extern unsigned short VIDEO_RECORDER_PORT;
++extern unsigned short NAVDATA_PORT;
++extern unsigned short VIDEO_PORT;
++extern unsigned short AT_PORT;
++extern unsigned short RAW_CAPTURE_PORT;
++extern unsigned short PRINTF_PORT;
++extern unsigned short CONTROL_PORT;
+ 
+ ///////////////////////////////////////////////
+ // Wired configuration
 diff --git a/ARDroneLib/Soft/Lib/ardrone_tool/ardrone_tool.c b/ARDroneLib/Soft/Lib/ardrone_tool/ardrone_tool.c
-index 8466d4c..0b4f2e7 100644
+index 8466d4c..8dd43cd 100644
 --- a/ARDroneLib/Soft/Lib/ardrone_tool/ardrone_tool.c
 +++ b/ARDroneLib/Soft/Lib/ardrone_tool/ardrone_tool.c
 @@ -332,11 +332,11 @@ int ardrone_tool_main(int argc, char **argv)
@@ -29,11 +60,40 @@ index 8466d4c..0b4f2e7 100644
    
    /* After a first analysis, the arguments are restored so they can be passed to the user-defined functions */
    argc=argc_backup;
+@@ -420,6 +420,28 @@ int ardrone_tool_main(int argc, char **argv)
+   return SUCCEED(res) ? 0 : -1;
+ }
+ 
++// Set default ports for variables that replace old constants
++unsigned short FTP_PORT                 = 5551;
++unsigned short AUTH_PORT                = 5552;
++unsigned short VIDEO_RECORDER_PORT      = 5553;
++unsigned short NAVDATA_PORT             = 5554;
++unsigned short VIDEO_PORT               = 5555;
++unsigned short AT_PORT                  = 5556;
++unsigned short RAW_CAPTURE_PORT         = 5557;
++unsigned short PRINTF_PORT              = 5558;
++unsigned short CONTROL_PORT             = 5559;
++
++// Provide port setter functions for application
++void set_FTP_PORT(uint16_t p) { FTP_PORT = p; }
++void set_AUTH_PORT(uint16_t p) { AUTH_PORT = p; }
++void set_VIDEO_RECORDER_PORT(uint16_t p) { VIDEO_RECORDER_PORT = p; }
++void set_NAVDATA_PORT(uint16_t p) { NAVDATA_PORT = p; }
++void set_VIDEO_PORT(uint16_t p) { VIDEO_PORT = p; }
++void set_AT_PORT(uint16_t p) { AT_PORT = p; }
++void set_RAW_CAPTURE_PORT(uint16_t p) { RAW_CAPTURE_PORT = p; }
++void set_PRINTF_PORT(uint16_t p) { PRINTF_PORT = p; }
++void set_CONTROL_PORT(uint16_t p) { CONTROL_PORT = p; }
++
+ // Default implementation for weak functions
+ #ifndef _WIN32
+ 	C_RESULT ardrone_tool_init_custom(void) { return C_OK; }
 diff --git a/ARDroneLib/Soft/Lib/ardrone_tool/ardrone_tool.h b/ARDroneLib/Soft/Lib/ardrone_tool/ardrone_tool.h
-index a081c9a..93005ec 100644
+index a081c9a..f65a6da 100644
 --- a/ARDroneLib/Soft/Lib/ardrone_tool/ardrone_tool.h
 +++ b/ARDroneLib/Soft/Lib/ardrone_tool/ardrone_tool.h
-@@ -66,7 +66,7 @@ C_RESULT ardrone_tool_shutdown(void);
+@@ -66,12 +66,23 @@ C_RESULT ardrone_tool_shutdown(void);
  
  void ardrone_tool_init_timers_and_mutex();
  void ardrone_tool_send_com_watchdog(void); // To send it only once
@@ -42,6 +102,22 @@ index a081c9a..93005ec 100644
  
  // There because not defined in embedded
  void api_configuration_get_ctrl_mode(void);
+ void api_configuration_ack_ctrl_mode(void);
+ 
++// Provide port setter functions for application
++void set_FTP_PORT(uint16_t p);
++void set_AUTH_PORT(uint16_t p);
++void set_VIDEO_RECORDER_PORT(uint16_t p);
++void set_NAVDATA_PORT(uint16_t p);
++void set_VIDEO_PORT(uint16_t p);
++void set_AT_PORT(uint16_t p);
++void set_RAW_CAPTURE_PORT(uint16_t p);
++void set_PRINTF_PORT(uint16_t p);
++void set_CONTROL_PORT(uint16_t p);
++
+ /*! \page page2
+  * @defgroup ARDrone_Tool ARDrone_Tool
+ 
 diff --git a/ARDroneLib/VP_SDK/Build/Makefile b/ARDroneLib/VP_SDK/Build/Makefile
 index bda3259..27418d2 100644
 --- a/ARDroneLib/VP_SDK/Build/Makefile

--- a/src/ardrone_driver.cpp
+++ b/src/ardrone_driver.cpp
@@ -832,6 +832,51 @@ int main(int argc, char** argv)
             printf("Using custom ip address %s\n",drone_ip_address);
             argc--; argv++;
         }
+        else if ( !strcmp(*argv, "-ftp-port") && ( argc > 1 ) ) /* 5551 */
+        {
+            set_FTP_PORT((unsigned short)atoi(*(argv+1)));
+            argc--; argv++;
+        }
+        else if ( !strcmp(*argv, "-auth-port") && ( argc > 1 ) ) /* 5552 */
+        {
+            set_AUTH_PORT((unsigned short)atoi(*(argv+1)));
+            argc--; argv++;
+        }
+        else if ( !strcmp(*argv, "-video-recorder-port") && ( argc > 1 ) ) /* 5553 */
+        {
+            set_VIDEO_RECORDER_PORT((unsigned short)atoi(*(argv+1)));
+            argc--; argv++;
+        }
+        else if ( !strcmp(*argv, "-navdata-port") && ( argc > 1 ) ) /* 5554 */
+        {
+            set_NAVDATA_PORT((unsigned short)atoi(*(argv+1)));
+            argc--; argv++;
+        }
+        else if ( !strcmp(*argv, "-video-port") && ( argc > 1 ) ) /* 5555 */
+        {
+            set_VIDEO_PORT((unsigned short)atoi(*(argv+1)));
+            argc--; argv++;
+        }
+        else if ( !strcmp(*argv, "-at-port") && ( argc > 1 ) ) /* 5556 */
+        {
+            set_AT_PORT((unsigned short)atoi(*(argv+1)));
+            argc--; argv++;
+        }
+        else if ( !strcmp(*argv, "-raw-capture-port") && ( argc > 1 ) ) /* 5557 */
+        {
+            set_RAW_CAPTURE_PORT((unsigned short)atoi(*(argv+1)));
+            argc--; argv++;
+        }
+        else if ( !strcmp(*argv, "-printf-port") && ( argc > 1 ) ) /* 5558 */
+        {
+            set_PRINTF_PORT((unsigned short)atoi(*(argv+1)));
+            argc--; argv++;
+        }
+        else if ( !strcmp(*argv, "-control-port") && ( argc > 1 ) ) /* 5559 */
+        {
+            set_CONTROL_PORT((unsigned short)atoi(*(argv+1)));
+            argc--; argv++;
+        }
         argc--; argv++;
     }
 


### PR DESCRIPTION
This follows up on: https://github.com/AutonomyLab/ardrone_autonomy/issues/56#issuecomment-36702633

Note: this patch does NOT affect the default behavior of ardrone_driver; optional command-line arguments must be supplied to introduce the described behavior.

I've incorporated a solution for running multiple instances of ardrone_driver on a single computer. It is based on manually specifying custom ports for each instance of the ardrone_driver node and using iptables (root privileges required) to remap UDP packets en route to the standard ports on each quad. The options follow from the port names, e.g., -navdata-port, -video-port, and -at-port. As far as I can tell, these are the only three that need to be customized, but the other port numbers are also made into options for completeness.

To test: first, join the quads into a common network. Supposing two quads, q1 at 192.168.0.101 and q2 at 192.168.0.102, we choose to remap ports as follows:

q1: 5554 (quad) <-> 1554 (ardrone_driver), 5555 <-> 1555, 5556 <-> 1556
q2: 5554 (quad) <-> 2554 (ardrone_driver), 5555 <-> 2555, 5556 <-> 2556

The corresponding iptables commands would be:

q1:

``` bash
sudo iptables -t nat -A OUTPUT -p udp -d 192.168.0.101 --dport 1554 -j DNAT --to :5554
sudo iptables -t nat -A PREROUTING -p udp -s 192.168.0.101 --dport 5554 -j DNAT --to :1554
sudo iptables -t nat -A OUTPUT -p udp -d 192.168.0.101 --dport 1555 -j DNAT --to :5555
sudo iptables -t nat -A PREROUTING -p udp -s 192.168.0.101 --dport 5555 -j DNAT --to :1555
sudo iptables -t nat -A OUTPUT -p udp -d 192.168.0.101 --dport 1556 -j DNAT --to :5556
sudo iptables -t nat -A PREROUTING -p udp -s 192.168.0.101 --dport 5556 -j DNAT --to :1556
```

q2:

``` bash
sudo iptables -t nat -A OUTPUT -p udp -d 192.168.0.102 --dport 2554 -j DNAT --to :5554
sudo iptables -t nat -A PREROUTING -p udp -s 192.168.0.102 --dport 5554 -j DNAT --to :2554
sudo iptables -t nat -A OUTPUT -p udp -d 192.168.0.102 --dport 2555 -j DNAT --to :5555
sudo iptables -t nat -A PREROUTING -p udp -s 192.168.0.102 --dport 5555 -j DNAT --to :2555
sudo iptables -t nat -A OUTPUT -p udp -d 192.168.0.102 --dport 2556 -j DNAT --to :5556
sudo iptables -t nat -A PREROUTING -p udp -s 192.168.0.102 --dport 5556 -j DNAT --to :2556
```

Now, when running instances of ardrone_driver, add the following args strings:

q1:

``` bash
-ip 192.168.0.101 -navdata-port 1554 -video-port 1555 -at-port 1556
```

q2:

``` bash
-ip 192.168.0.102 -navdata-port 2554 -video-port 2555 -at-port 2556
```

More information as well as tools for automating wireless reconfiguration and port remapping are available here:
http://hacked10bits.blogspot.com/2014/02/multiple-ardrones-from-single-computer.html
