### PR TITLE
Fix ffmpeg library link order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ include_directories(${Boost_INCLUDE_DIRS})
 
 # build executable
 add_executable(ardrone_driver src/ardrone_driver.cpp src/video.cpp src/ardrone_sdk.cpp src/teleop_twist.cpp)
-target_link_libraries(ardrone_driver pc_ardrone avcodec avutil swscale vlib  sdk SDL ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(ardrone_driver pc_ardrone avcodec swscale avutil vlib  sdk SDL ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 #If you have a package which builds messages and/or services as well as
 #executables that use them, you need to create an explicit dependency on


### PR DESCRIPTION
libswscale depends on libavutil.

When compiling on Linux it doesn't have issues, but when I tried to cross-compile the driver on Android using the NDK r8e, it throws an error at linking about an undefined reference to av_get_cpu_flags which is part of libavutil. This fixes it.
