### PR TITLE
Add orientation support

### DIFF
--- a/src/teleop_twist.cpp
+++ b/src/teleop_twist.cpp
@@ -5,6 +5,8 @@
 #include <geographic_msgs/KeyValue.h>
 #include <vector>
 
+#define _RAD2DEG 57.2957184819
+
 inline float max(float a, float b) { return a > b ? a : b; }
 inline float min(float a, float b) { return a < b ? a : b; }
 inline bool in_rangef(float a, float _min, float _max) {return a >= _min && a <= _max; } //inclusive
@@ -130,9 +132,10 @@ bool setAutomousFlightCallback(ardrone_autonomy::RecordEnable::Request &request,
 bool setGPSTargetWayPointCallback(ardrone_autonomy::SetGPSTarget::Request &request, ardrone_autonomy::SetGPSTarget::Response &response){
 
     //"10000,0,492767188,-1229157891,994,165,165,525000,0,0"
+    //"10000,0,lat,long,alt,vx,vy,525000,orientation(degrees*100),0"
     char param_str[255];
     long int lat = 0, lon = 0;
-    int alt = 0, v = 0;
+    int alt = 0, v = 0, orientation = 0;
 
     if (
             in_rangef(request.target.position.latitude, -90.0, 90.0) &&
@@ -148,14 +151,24 @@ bool setGPSTargetWayPointCallback(ardrone_autonomy::SetGPSTarget::Request &reque
         return false;
     }
 
-    if ((request.target.props.size() == 1) && (request.target.props[0].key == "velocity")) {
-        v = (int) round(atof(request.target.props[0].value.c_str()) * 1000.0); // mm/s
-        if (!in_range(v, 0, 10000)) { // max: 10m/s
-            fprintf(stderr, "Requested velocity is not in range: %d\n", v);
-            return false;
+    // Set default values
+    v = 500;
+    orientation = 0;
+
+    for(int i = 0; i < request.target.props.size(); i++){
+        if(request.target.props[i].key == "velocity"){
+            v = (int) round(atof(request.target.props[i].value.c_str()) * 1000.0); // mm/s
+            if (!in_range(v, 0, 10000)) { // max: 10m/s
+                fprintf(stderr, "Requested velocity is not in range: %d\n", v);
+                return false;
+            }
+        }else if(request.target.props[i].key == "orientation"){
+            orientation = (int) round(atof(request.target.props[i].value.c_str()) * _RAD2DEG * 100.0); // degrees
+            if (!in_range(orientation, -36000, 36000)) { // max: 360 degrees
+                fprintf(stderr, "Requested orientation is not in range: %d\n", orientation);
+                return false;
+            }
         }
-    } else {
-        v = 500;
     }
 
     sprintf(param_str,"%d,%d,%ld,%ld,%d,%d,%d,%d,%d,%d",
@@ -167,7 +180,7 @@ bool setGPSTargetWayPointCallback(ardrone_autonomy::SetGPSTarget::Request &reque
             v,
             v,
             525000,
-            0,
+            orientation,
             0
             );
 


### PR DESCRIPTION
Add support for specifying the desired orientation in radians. If orientation = 0, the drone first rotates to face the goal and goes straight, else, the drone first rotates to the desired orientation (0 being facing north) and then moves to the goal maintaining the orientation.

We may need to modify the rotation in order to complain with REP103.
