### PR TITLE
Fixed error with odometry caused by clockwise/counterclockwise angles

### DIFF
--- a/src/ardrone_driver.cpp
+++ b/src/ardrone_driver.cpp
@@ -686,11 +686,12 @@ void ARDroneDriver::PublishOdometry(const navdata_unpacked_t &navdata_raw, const
   if (last_receive_time.isValid())
   {
     double delta_t = (navdata_receive_time - last_receive_time).toSec();
-    odometry[0] += ((cos((navdata_raw.navdata_demo.psi / 180000.0) * M_PI) *
-                     navdata_raw.navdata_demo.vx - sin((navdata_raw.navdata_demo.psi / 180000.0) * M_PI) *
+    double yaw_angle = -(navdata_raw.navdata_demo.psi / 180000.0) * M_PI;
+    odometry[0] += ((cos(yaw_angle) *
+                     navdata_raw.navdata_demo.vx - sin(yaw_angle) *
                      -navdata_raw.navdata_demo.vy) * delta_t) / 1000.0;
-    odometry[1] += ((sin((navdata_raw.navdata_demo.psi / 180000.0) * M_PI) *
-                     navdata_raw.navdata_demo.vx + cos((navdata_raw.navdata_demo.psi / 180000.0) * M_PI) *
+    odometry[1] += ((sin(yaw_angle) *
+                     navdata_raw.navdata_demo.vx + cos(yaw_angle) *
                      -navdata_raw.navdata_demo.vy) * delta_t) / 1000.0;
   }
   last_receive_time = navdata_receive_time;


### PR DESCRIPTION
During testing with the AR Drone 2.0, we noticed that odometry and state estimation was behaving incorrectly when the drone was not facing North or South. We tracked this down to a missing negative sign in the state estimate calculations, caused by clockwise angles coming from the drone, and counterclockwise angles expected by the trigonometry.